### PR TITLE
Allow printing to up to 300mm width or depth

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -40,11 +40,11 @@ const MAX_LEVELS = 5;
 
 const START_WIDTH = 80;
 const MIN_WIDTH = 10 + 2 * START_RADIUS;
-const MAX_WIDTH = 204; /* somewhat arbitrary */
+const MAX_WIDTH = 304; /* somewhat arbitrary */
 
 const START_DEPTH = 60;
 const MIN_DEPTH = 20;
-const MAX_DEPTH = 204; /* somewhat arbitrary */
+const MAX_DEPTH = 304; /* somewhat arbitrary */
 
 /// STATE
 


### PR DESCRIPTION
Increase the maximum width and depth for generated 3MF models from 200mm to 300mm.

Changes:
- Updated MAX_WIDTH from 204mm to 304mm
- Updated MAX_DEPTH from 204mm to 304mm

(The outer dimensions include 4mm for wall thickness, allowing inner dimensions up to 300mm)

Addresses #44 